### PR TITLE
Add scope tracking for combining forms, chainReducers combinator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,3 +6,4 @@ lazy val scalaJsReactReduxForm = Projects.scalaJsReactReduxForm
 
 lazy val exRaw = Projects.exRaw
 lazy val exTyped = Projects.exTyped
+lazy val exCombine = Projects.exCombine

--- a/examples/combine/config/webpack.config.js
+++ b/examples/combine/config/webpack.config.js
@@ -1,0 +1,21 @@
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+var cfg = require('./scalajs.webpack.config');
+var path = require('path');
+var rootDir = path.dirname(path.dirname(path.dirname(path.dirname(__dirname))));
+
+cfg.output.path = path.join(rootDir, 'build');
+
+cfg.module = cfg.module || {};
+cfg.module.loaders = cfg.module.loaders || [];
+cfg.module.loaders.push({
+  test: /\.html$/,
+  loader: 'html'
+});
+
+cfg.plugins = cfg.plugins || [];
+cfg.plugins.push(new HtmlWebpackPlugin({
+  template: path.join(rootDir, 'src/main/assets/index.html')
+}));
+
+module.exports = cfg;
+ 

--- a/examples/combine/src/main/assets/index.html
+++ b/examples/combine/src/main/assets/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8"/>
+    <title>scalajs-react-redux-form example: raw</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/combine/src/main/scala/Components.scala
+++ b/examples/combine/src/main/scala/Components.scala
@@ -1,5 +1,7 @@
 package eldis.redux.rrf.examples.typed
 
+import scala.scalajs.js
+
 import eldis.react._
 import vdom.prefix_<^._
 
@@ -16,4 +18,18 @@ object Message {
   )
 
   def apply() = connected((), Seq())
+}
+
+// Header with data, provided by React Redux Form
+object Header {
+
+  @js.native
+  trait Props extends js.Object {
+    // provided by rrf
+    def value: String
+  }
+
+  val component = NativeFunctionalComponent[Props]("Header") {
+    (p: Props) => <.h3()(p.value)
+  }
 }

--- a/examples/combine/src/main/scala/Components.scala
+++ b/examples/combine/src/main/scala/Components.scala
@@ -1,0 +1,19 @@
+package eldis.redux.rrf.examples.typed
+
+import eldis.react._
+import vdom.prefix_<^._
+
+import eldis.redux.react.{ eldis => react }
+
+object Message {
+  val component = FunctionalComponent[String]("Message") {
+    (s: String) => <.p()(s)
+  }
+
+  val connected = react.connect(
+    (state: Main.State, ownProps: Unit) => state.message,
+    component
+  )
+
+  def apply() = connected((), Seq())
+}

--- a/examples/combine/src/main/scala/Main.scala
+++ b/examples/combine/src/main/scala/Main.scala
@@ -12,7 +12,7 @@ import eldis.redux._
 import eldis.redux.react.{ eldis => react }
 
 import eldis.redux.rrf
-import rrf.{ combineFormsUnscoped, Forms, StringLens, Scoped, Unscoped }
+import rrf.{ combineFormsUnscoped, Forms, StringLens, Scoped, Unscoped, RRFState }
 import rrf.util.chainReducers
 
 /**
@@ -25,6 +25,14 @@ object Main extends js.JSApp {
   @ScalaJSDefined
   trait Deep extends js.Object {
     val testForm: UserForm.State
+
+    // This is not used by any RRF form reducer. `combineForms` would
+    // complain about this being present in initial state, but
+    // `chainReducers` is more permissive.
+    val header: String
+
+    // Data used by RRF internally
+    val rrfData: RRFState = js.undefined
   }
 
   @ScalaJSDefined
@@ -37,12 +45,13 @@ object Main extends js.JSApp {
     new State {
       val deep = new Deep {
         val testForm = UserForm.initialState
+        val header = "Enter your data, please:"
       }
 
-      // This is neither handled by RRF, nor by a local reducer. Stock
+      // This is not handled by a local reducer. Stock
       // `combineReducers` would complain if this was present in initial
       // state. `chainReducers` is more permissive here.
-      val message = "default message"
+      val message = "Enter password"
     }
 
   def App(store: Store[js.Any, Action]) = {
@@ -64,14 +73,12 @@ object Main extends js.JSApp {
 
   def main(): Unit = {
     // This is only scoped to `Deep` - it doesn't know about the global state
-    val forms = Forms(
-      StringLens[Deep, UserForm.State]("testForm") -> UserForm.initialState
-    )
-
-    // Notice that this is unscoped - we didn't yet provide the path
-    // to this in global state.
-    val formsReducer: Unscoped[Deep, Reducer[Deep, Action]] =
-      combineFormsUnscoped(forms)
+    val forms: Forms[Deep, Action] = Forms(
+      // path to rrf data
+      StringLens[Deep, RRFState]("rrfData")
+    )(
+        StringLens[Deep, UserForm.State]("testForm") -> UserForm.initialState
+      )
 
     // This is global, since it needs access to the form data. It also
     // is a raw reducer - since we have to spy on rrf actions.
@@ -92,7 +99,7 @@ object Main extends js.JSApp {
     val rawReducer: Reducer[State, Action] =
       chainReducers(
         // Scoping happens here
-        StringLens[State, Deep]("deep") -> formsReducer,
+        StringLens[State, Deep]("deep") -> forms,
         customReducer
       )
 

--- a/examples/combine/src/main/scala/Main.scala
+++ b/examples/combine/src/main/scala/Main.scala
@@ -12,7 +12,7 @@ import eldis.redux._
 import eldis.redux.react.{ eldis => react }
 
 import eldis.redux.rrf
-import rrf.{ combineFormsUnscoped, Forms, StringLens, Scoped, Unscoped, RRFState }
+import rrf.{ combineFormsUnscoped, Forms, GenLens, Scoped, Unscoped, RRFState }
 import rrf.util.chainReducers
 
 /**
@@ -28,7 +28,7 @@ object Main extends js.JSApp {
 
     // This is not used by any RRF form reducer. `combineForms` would
     // complain about this being present in initial state, but
-    // `chainReducers` is more permissive.
+    // `chainReducers` is more permissive...
     val header: String
 
     // Data used by RRF internally
@@ -75,9 +75,9 @@ object Main extends js.JSApp {
     // This is only scoped to `Deep` - it doesn't know about the global state
     val forms: Forms[Deep, Action] = Forms(
       // path to rrf data
-      StringLens[Deep, RRFState]("rrfData")
+      GenLens[Deep](_.rrfData)
     )(
-        StringLens[Deep, UserForm.State]("testForm") -> UserForm.initialState
+        GenLens[Deep](_.testForm) -> UserForm.initialState
       )
 
     // This is global, since it needs access to the form data. It also
@@ -99,7 +99,7 @@ object Main extends js.JSApp {
     val rawReducer: Reducer[State, Action] =
       chainReducers(
         // Scoping happens here
-        StringLens[State, Deep]("deep") -> forms,
+        GenLens[State](_.deep) -> forms,
         customReducer
       )
 

--- a/examples/combine/src/main/scala/Main.scala
+++ b/examples/combine/src/main/scala/Main.scala
@@ -1,0 +1,109 @@
+package eldis.redux.rrf.examples.typed
+
+import scalajs.js
+import org.scalajs.dom
+import js.annotation._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import eldis.react._
+import vdom.prefix_<^._
+
+import eldis.redux._
+import eldis.redux.react.{ eldis => react }
+
+import eldis.redux.rrf
+import rrf.{ combineFormsUnscoped, Forms, StringLens, Scoped, Unscoped }
+import rrf.util.chainReducers
+
+/**
+ * An example of nesting forms and scoping reducers.
+ */
+object Main extends js.JSApp {
+
+  type Action = js.Object
+
+  @ScalaJSDefined
+  trait Deep extends js.Object {
+    val testForm: UserForm.State
+  }
+
+  @ScalaJSDefined
+  trait State extends js.Object {
+    val deep: Deep
+    val message: String
+  }
+
+  val initialState =
+    new State {
+      val deep = new Deep {
+        val testForm = UserForm.initialState
+      }
+
+      // This is neither handled by RRF, nor by a local reducer. Stock
+      // `combineReducers` would complain if this was present in initial
+      // state. `chainReducers` is more permissive here.
+      val message = "default message"
+    }
+
+  def App(store: Store[js.Any, Action]) = {
+    val form = UserForm()
+    react.Provider(store)(
+      <.div()(
+        form,
+        <.br()(),
+        Message()
+      )
+    )
+  }
+
+  @JSImport("redux-logger", JSImport.Namespace)
+  @js.native
+  object createLogger extends js.Object {
+    def apply(): Middleware[js.Any, Action] = js.native
+  }
+
+  def main(): Unit = {
+    // This is only scoped to `Deep` - it doesn't know about the global state
+    val forms = Forms(
+      StringLens[Deep, UserForm.State]("testForm") -> UserForm.initialState
+    )
+
+    // Notice that this is unscoped - we didn't yet provide the path
+    // to this in global state.
+    val formsReducer: Unscoped[Deep, Reducer[Deep, Action]] =
+      combineFormsUnscoped(forms)
+
+    // This is global, since it needs access to the form data. It also
+    // is a raw reducer - since we have to spy on rrf actions.
+    val customReducer: Reducer[State, Action] =
+      (s: State, a: Action) =>
+        a.asInstanceOf[js.Dictionary[js.Any]]("type").asInstanceOf[String] match {
+          case "rrf/change" =>
+            new State {
+              val deep = s.deep
+              val message = s"Password length: ${s.deep.testForm.pass.length}"
+            }
+          case _ => s
+        }
+
+    // `chainReducers` is an alternative to `combineReducers` that
+    // supports scoping and doesn't complain about the shape of initial
+    // state.
+    val rawReducer: Reducer[State, Action] =
+      chainReducers(
+        // Scoping happens here
+        StringLens[State, Deep]("deep") -> formsReducer,
+        customReducer
+      )
+
+    val store = createStore(
+      (s: js.Any, a: js.Any) => s,
+      initialState,
+      rawReducer: js.Function,
+      applyMiddleware(Seq(createLogger()))
+    )
+
+    ReactDOM.render(App(store), dom.document.getElementById("root"))
+  }
+
+}

--- a/examples/combine/src/main/scala/UserForm.scala
+++ b/examples/combine/src/main/scala/UserForm.scala
@@ -1,0 +1,48 @@
+package eldis.redux.rrf.examples.typed
+
+import scalajs.js
+import js.annotation.ScalaJSDefined
+import eldis.react._
+import vdom.Style
+import vdom.prefix_<^._
+import eldis.redux.rrf._
+
+object UserForm {
+
+  @ScalaJSDefined
+  trait State extends js.Object {
+    val user: String
+    val pass: String
+  }
+
+  val initialState = new State {
+    val user = "test"
+    val pass = ""
+  }
+
+  val component = FunctionalComponent[String]("UserForm") { _ =>
+    Form(Form.Props(
+      // We need full path here.
+      StringLens[Main.State, UserForm.State]("deep.testForm")
+    ))(
+      <.label()("Username:"),
+      Control(Control.Props(
+        GenLens[UserForm.State](_.user),
+        component = Some(CustomInput.component)
+      ))(),
+      <.label()("Password:"),
+      Control(
+        Control.Props(GenLens[UserForm.State](_.pass)),
+        vdom.Attrs(^.`type` := "password").toJs
+      )(),
+      <.br()(),
+      Control.button(Control.Props(GenLens[UserForm.State](_.user)))(
+        ^.style := Style(
+          "color" -> "blue"
+        )
+      )("Submit")
+    )
+  }
+  def apply(): ReactDOMElement = React.createElement(component, "")
+
+}

--- a/examples/combine/src/main/scala/UserForm.scala
+++ b/examples/combine/src/main/scala/UserForm.scala
@@ -25,6 +25,10 @@ object UserForm {
       // We need full path here.
       StringLens[Main.State, UserForm.State]("deep.testForm")
     ))(
+      Control(Control.Props(
+        StringLens[Main.State, String]("deep.header"),
+        component = Some(Header.component)
+      ))(),
       <.label()("Username:"),
       Control(Control.Props(
         GenLens[UserForm.State](_.user),

--- a/examples/combine/src/main/scala/UserForm.scala
+++ b/examples/combine/src/main/scala/UserForm.scala
@@ -23,24 +23,25 @@ object UserForm {
   val component = FunctionalComponent[String]("UserForm") { _ =>
     Form(Form.Props(
       // We need full path here.
-      StringLens[Main.State, UserForm.State]("deep.testForm")
+      GenLens[Main.State](_.deep.testForm)
     ))(
       Control(Control.Props(
-        StringLens[Main.State, String]("deep.header"),
+        GenLens[Main.State](_.deep.header),
         component = Some(Header.component)
       ))(),
       <.label()("Username:"),
       Control(Control.Props(
-        GenLens[UserForm.State](_.user),
+        // Notice `.partial` - this makes the path relative to form model
+        GenLens[UserForm.State](_.user).partial,
         component = Some(CustomInput.component)
       ))(),
       <.label()("Password:"),
       Control(
-        Control.Props(GenLens[UserForm.State](_.pass)),
+        Control.Props(GenLens[UserForm.State](_.pass).partial),
         vdom.Attrs(^.`type` := "password").toJs
       )(),
       <.br()(),
-      Control.button(Control.Props(GenLens[UserForm.State](_.user)))(
+      Control.button(Control.Props(GenLens[UserForm.State](_.user).partial))(
         ^.style := Style(
           "color" -> "blue"
         )

--- a/examples/typed/src/main/scala/Main.scala
+++ b/examples/typed/src/main/scala/Main.scala
@@ -10,7 +10,7 @@ import eldis.react._
 import eldis.redux._
 import eldis.redux.react.{ eldis => react }
 
-import eldis.redux.rrf.{ combineForms, Forms, StringLens }
+import eldis.redux.rrf.{ combineForms, Forms, StringLens, RRFState }
 
 object Main extends js.JSApp {
 
@@ -19,6 +19,7 @@ object Main extends js.JSApp {
   @ScalaJSDefined
   trait State extends js.Object {
     val testForm: UserForm.State
+    val rrfData: RRFState = js.undefined
   }
 
   def App(store: Store[js.Any, Action]) = {
@@ -35,7 +36,7 @@ object Main extends js.JSApp {
   }
 
   def main(): Unit = {
-    val forms = Forms(
+    val forms = Forms(StringLens[State, RRFState]("rrfData"))(
       StringLens[State, UserForm.State]("testForm") -> UserForm.initialState
     )
     val store = createStore(

--- a/examples/typed/src/main/scala/Main.scala
+++ b/examples/typed/src/main/scala/Main.scala
@@ -36,15 +36,12 @@ object Main extends js.JSApp {
 
   def main(): Unit = {
     val forms = Forms(
-      Forms.StatePair(
-        StringLens[State, UserForm.State]("testForm"),
-        UserForm.initialState
-      )
+      StringLens[State, UserForm.State]("testForm") -> UserForm.initialState
     )
     val store = createStore(
       (s: js.Any, a: js.Any) => s,
       js.undefined,
-      combineForms(forms): js.Function,
+      combineForms(forms).run: js.Function,
       applyMiddleware(Seq(createLogger()))
     )
 

--- a/examples/typed/src/main/scala/Main.scala
+++ b/examples/typed/src/main/scala/Main.scala
@@ -10,7 +10,7 @@ import eldis.react._
 import eldis.redux._
 import eldis.redux.react.{ eldis => react }
 
-import eldis.redux.rrf.{ combineForms, Forms, StringLens, RRFState }
+import eldis.redux.rrf.{ combineForms, Forms, GenLens, RRFState }
 
 object Main extends js.JSApp {
 
@@ -19,6 +19,7 @@ object Main extends js.JSApp {
   @ScalaJSDefined
   trait State extends js.Object {
     val testForm: UserForm.State
+    // RRF handles this - we only need to prepare a place for it.
     val rrfData: RRFState = js.undefined
   }
 
@@ -36,8 +37,8 @@ object Main extends js.JSApp {
   }
 
   def main(): Unit = {
-    val forms = Forms(StringLens[State, RRFState]("rrfData"))(
-      StringLens[State, UserForm.State]("testForm") -> UserForm.initialState
+    val forms = Forms(GenLens[State](_.rrfData))(
+      GenLens[State](_.testForm) -> UserForm.initialState
     )
     val store = createStore(
       (s: js.Any, a: js.Any) => s,

--- a/examples/typed/src/main/scala/UserForm.scala
+++ b/examples/typed/src/main/scala/UserForm.scala
@@ -22,21 +22,21 @@ object UserForm {
 
   val component = FunctionalComponent[String]("UserForm") { _ =>
     Form(Form.Props(
-      StringLens[Main.State, UserForm.State]("testForm")
+      GenLens[Main.State](_.testForm)
     ))(
       <.label()("Username:"),
       Control(Control.Props(
-        // Create lens manually
-        GenLens[UserForm.State](_.user),
+        // `.partial` makes the path relative to form model
+        GenLens[UserForm.State](_.user).partial,
         component = Some(CustomInput.component)
       ))(),
       <.label()("Password:"),
       Control(
-        Control.Props(StringLens[UserForm.State, String](".pass")),
+        Control.Props(GenLens[UserForm.State](_.pass).partial),
         vdom.Attrs(^.`type` := "password").toJs
       )(),
       <.br()(),
-      Control.button(Control.Props(GenLens[UserForm.State](_.user)))(
+      Control.button(Control.Props(GenLens[UserForm.State](_.user).partial))(
         ^.style := Style(
           "color" -> "blue"
         )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -42,7 +42,9 @@ object ScalaJSReactReduxForm {
       "react-redux-form" -> JsVersions.reactReduxForm,
 
       // Doesn't affect footprint - rrf uses it internally
-      "lodash.get" -> JsVersions.lodash
+
+      "lodash.get" -> JsVersions.lodash,
+      "lodash.topath" -> JsVersions.lodash
     )
 
     lazy val jsReduxLogger = "redux-logger" -> JsVersions.reduxLogger

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -140,6 +140,12 @@ object ScalaJSReactReduxForm {
         Settings.exampleProject("typed")
       )
       .dependsOn(scalaJsReactReduxForm)
+
+    lazy val exCombine = project
+      .configure(
+        Settings.exampleProject("combine")
+      )
+      .dependsOn(scalaJsReactReduxForm)
   }
 }
 

--- a/src/main/scala/Forms.scala
+++ b/src/main/scala/Forms.scala
@@ -19,7 +19,7 @@ import eldis.redux.Reducer
  * @param A Top action type
  */
 @ScalaJSDefined
-trait Forms[S, A] extends js.Any
+trait Forms[S, -A] extends js.Any
 
 object Forms {
 
@@ -55,6 +55,9 @@ object Forms {
   @inline
   def raw(self: Forms[_, _]) = self.asInstanceOf[js.Object]
 
+  /**
+   * A magnet to support entries in various shapes.
+   */
   case class Pair[S1, S2, -A](
     model: StringLens[S1, S2],
     value: Either[Unscoped[S2, Reducer[S2, A]], S2]

--- a/src/main/scala/GenLens.scala
+++ b/src/main/scala/GenLens.scala
@@ -22,15 +22,15 @@ object GenLens {
    * case class Bar(foo: Foo)
    *
    * // These are identical
-   * val sl1 = StringLens[Bar, Int](".foo.x")
+   * val sl1 = StringLens[Bar, Int]("foo.x")
    * // But this is a bit shorter and safer
    * val sl2 = GenLens[Bar](_.foo.x)
    *
    * }}}
    *
-   * The function must be in shape "_.foo.bar.baz"
-   * Currently only partial models are supported.
-   *
+   * The function must be in shape `_.foo.bar.baz`. All members are
+   * assumed to be fields, and to be exposed to JavaScript with the same
+   * names (though this isn't currently enforced).
    */
   @inline
   def apply[A] = new GenLens[A]()
@@ -74,6 +74,6 @@ object GenLensMacros {
     }
 
     // TODO: Empty path leads to empty string - is this OK?
-    "." + worker(body).reverse.mkString(".")
+    worker(body).reverse.mkString(".")
   }
 }

--- a/src/main/scala/ModelLens.scala
+++ b/src/main/scala/ModelLens.scala
@@ -45,16 +45,16 @@ object ModelLens {
    * Warning: this freezes `a`!
    */
   @inline
-  def get[A, B](f: ModelLens[A, B], a: A): B =
-    StringLens.get(makeStringLens(f, a), a)
+  def get[A, B](f: ModelLens[A, B])(a: A): B =
+    StringLens.get(makeStringLens(f, a))(a)
 
   @inline
-  def set[A, B](f: ModelLens[A, B], a: A)(b: B): A =
-    StringLens.set(makeStringLens(f, a), a)(b)
+  def set[A, B](f: ModelLens[A, B], b: B)(a: A): A =
+    StringLens.set(makeStringLens(f, a), b)(a)
 
   @inline
-  def over[A, B](f: ModelLens[A, B], a: A)(g: B => B): A =
-    StringLens.over(makeStringLens(f, a), a)(g)
+  def over[A, B](f: ModelLens[A, B])(g: B => B)(a: A): A =
+    StringLens.over(makeStringLens(f, a))(g)(a)
 
   def makeStringLens[A, B](f: ModelLens[A, B], a: A): StringLens[A, B] =
     f match {
@@ -80,13 +80,13 @@ object ModelLens {
         fromLensFunction[A, C](a => StringLens.compose(f, g(a)))
       case (FunctionML(f), StringML(g)) =>
         fromLensFunction[A, C](a => {
-          val submodel = StringLens.get(g, a)
+          val submodel = StringLens.get(g)(a)
           StringLens.compose(f(submodel), g)
         })
       case (FunctionML(f), FunctionML(g)) =>
         FunctionML[A, C]((a: A) => {
           val gSL: StringLens[A, B] = g(a)
-          val submodel = StringLens.get(gSL, a)
+          val submodel = StringLens.get(gSL)(a)
           val fSL: StringLens[B, C] = f(submodel)
           StringLens.compose(fSL, gSL)
         })
@@ -130,7 +130,7 @@ object ModelLens {
   implicit class ModelLensOps[A, B](self: ModelLens[A, B]) {
 
     @inline
-    def apply(a: A): B = ModelLens.get(self, a)
+    def apply(a: A): B = ModelLens.get(self)(a)
 
     @inline
     def makeStringLens(a: A): StringLens[A, B] =

--- a/src/main/scala/Scoped.scala
+++ b/src/main/scala/Scoped.scala
@@ -1,0 +1,45 @@
+package eldis.redux.rrf
+
+/**
+ * A type to express that the value expects `G` as the global state.
+ */
+case class Scoped[G, +T](run: T)
+
+object Scoped {
+
+  trait Factory[G] {
+    def apply[T](run: T): Scoped[G, T]
+  }
+
+  def apply[G] = new Factory[G] {
+    def apply[T](run: T) = Scoped[G, T](run)
+  }
+}
+
+/**
+ * A type that can be scoped to an arbitrary global state type.
+ *
+ * This pattern is generally useful for nesting and combining
+ * reducers and reducer-like objects.
+ * Conceptually this is `StringLens[?, S] ~> Scoped[?, T]`
+ */
+trait Unscoped[S, +T] {
+  def scope[G](lens: StringLens[G, S]): Scoped[G, T]
+  // TODO: clean up this whole self/global/partial model debacle
+  def scopeSelf: Scoped[S, T]
+}
+
+object Unscoped {
+
+  def apply[S, T](
+    f: Option[StringLens[_, S]] => T
+  ): Unscoped[S, T] = new Unscoped[S, T] {
+    def scope[G](lens: StringLens[G, S]) = Scoped[G](f(Some(lens)))
+    def scopeSelf = Scoped[S](f(None))
+  }
+
+  // Unscoped objects are implicitly scoped to their substate
+  // type for convenience
+  implicit def scopeSelf[S, T](u: Unscoped[S, T]): Scoped[S, T] =
+    u.scopeSelf
+}

--- a/src/main/scala/StringLens.scala
+++ b/src/main/scala/StringLens.scala
@@ -33,7 +33,7 @@ object StringLens {
   @inline
   def self[A]: StringLens[A, A] = StringLens[A, A]("")
 
-  def get[A, B](f: StringLens[A, B], a: A): B =
+  def get[A, B](f: StringLens[A, B])(a: A): B =
     // TODO: lodashToPath + lodashSet to match the implementation in RRF
     if ("" == f) {
       a.asInstanceOf[B]
@@ -49,7 +49,7 @@ object StringLens {
    *
    * Warning: this freezes `a`!
    */
-  def set[A, B](f: StringLens[A, B], a: A)(b: B): A =
+  def set[A, B](f: StringLens[A, B], b: B)(a: A): A =
     // Mismatched with get - same as RRF
     impl.icepick.setIn(
       a.asInstanceOf[js.Any],
@@ -57,8 +57,11 @@ object StringLens {
       b.asInstanceOf[js.Any]
     ).asInstanceOf[A]
 
-  def over[A, B](f: StringLens[A, B], a: A)(g: B => B): A =
-    set(f, a)(g(get(f, a)))
+  def over[A, B](f: StringLens[A, B])(g: B => B)(a: A): A = {
+    val before = get(f)(a)
+    val after = g(before)
+    set(f, after)(a)
+  }
 
   @inline
   def compose[A, B, C](f: StringLens[B, C], g: StringLens[A, B]): StringLens[A, C] =

--- a/src/main/scala/StringLens.scala
+++ b/src/main/scala/StringLens.scala
@@ -33,15 +33,32 @@ object StringLens {
   @inline
   def self[A]: StringLens[A, A] = StringLens[A, A]("")
 
-  def applyLens[A, B](f: StringLens[A, B], a: A): B =
+  def get[A, B](f: StringLens[A, B], a: A): B =
+    // TODO: lodashToPath + lodashSet to match the implementation in RRF
     if ("" == f) {
       a.asInstanceOf[B]
     } else {
       impl.lodashGet(
-        a.asInstanceOf[js.Object],
+        a.asInstanceOf[js.Any],
         run(f)
       ).asInstanceOf[B]
     }
+
+  /**
+   * Creates a copy of `a` with `b` at path `f`.
+   *
+   * Warning: this freezes `a`!
+   */
+  def set[A, B](f: StringLens[A, B], a: A)(b: B): A =
+    // Mismatched with get - same as RRF
+    impl.icepick.setIn(
+      a.asInstanceOf[js.Any],
+      impl.lodashToPath(run(f)),
+      b.asInstanceOf[js.Any]
+    ).asInstanceOf[A]
+
+  def over[A, B](f: StringLens[A, B], a: A)(g: B => B): A =
+    set(f, a)(g(get(f, a)))
 
   @inline
   def compose[A, B, C](f: StringLens[B, C], g: StringLens[A, B]): StringLens[A, C] =

--- a/src/main/scala/impl.scala
+++ b/src/main/scala/impl.scala
@@ -5,9 +5,22 @@ import js._
 import js.annotation._
 
 package object impl {
+
   @JSImport("lodash.get", JSImport.Default)
   @js.native
   object lodashGet extends js.Function3[js.Any, String | js.Array[String], js.UndefOr[js.Any], js.Any] {
     override def apply(obj: js.Any, path: String | js.Array[String], default: js.UndefOr[js.Any] = js.undefined): js.Any = js.native
+  }
+
+  @JSImport("lodash.topath", JSImport.Default)
+  @js.native
+  object lodashToPath extends js.Function1[js.Any, js.Array[String]] {
+    override def apply(value: js.Any): js.Array[String] = js.native
+  }
+
+  @JSImport("icepick", JSImport.Default)
+  @js.native
+  object icepick extends js.Object {
+    def setIn(obj: js.Any, path: js.Array[String], value: js.Any): js.Any = js.native
   }
 }

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -2,6 +2,7 @@ package eldis.redux
 
 import scala.scalajs.js
 import js.annotation._
+import js.JSConverters._
 
 /**
  * More type-safe API for rrf package.
@@ -10,41 +11,67 @@ package object rrf {
 
   type SubmitHandler[S] = js.Function1[S, Unit]
 
-  @js.native
+  @ScalaJSDefined
   trait CombineFormsOptions extends js.Object {
-    def key: js.UndefOr[String] = js.native
+    val key: js.UndefOr[String] = js.undefined
     // TODO: better typing here
-    def plugins: js.UndefOr[js.Array[_]] = js.native
+    val plugins: js.UndefOr[js.Array[_]] = js.undefined
   }
 
   object CombineFormsOptions {
     def apply(
-      key: js.UndefOr[String] = js.undefined,
-      plugins: js.UndefOr[js.Array[_]] = js.undefined
-    ) = js.Dynamic.literal(
-      key = key,
-      plugins = plugins
-    ).asInstanceOf[CombineFormsOptions]
+      key: Option[String] = None,
+      plugins: Option[js.Array[_]] = None
+    ) = {
+      val key0 = key
+      val plugins0 = plugins
+      new CombineFormsOptions {
+        override val key = key0.orUndefined
+        override val plugins = plugins0.orUndefined
+      }
+    }
   }
 
-  def combineForms[S1, S2, A](
-    forms: Forms[S2, A],
-    model: js.UndefOr[StringLens[S1, S2]] = js.undefined,
-    options: js.UndefOr[CombineFormsOptions] = js.undefined
-  ): Reducer[S1, A] = raw.impl.combineForms(
-    Forms.raw(forms),
-    model.map(StringLens.run),
-    options
-  ).asInstanceOf[Reducer[S1, A]]
+  def combineForms[G, S, A](
+    forms: Unscoped[S, Forms[S, A]],
+    model: StringLens[G, S],
+    options: Option[CombineFormsOptions]
+  ): Scoped[G, Reducer[S, A]] = Scoped[G](
+    raw.impl.combineForms(
+    Forms.raw(forms.scope(model).run),
+    StringLens.run(model),
+    options.orUndefined
+  ).asInstanceOf[Reducer[S, A]]
+  )
 
-  def modelReducer[S1, S2, A](
-    model: StringLens[S1, S2],
-    initialState: S2
-  ): Reducer[S1, A] =
+  def combineForms[S, A](
+    forms: Scoped[S, Forms[S, A]],
+    options: Option[CombineFormsOptions] = None
+  ): Scoped[S, Reducer[S, A]] = Scoped[S](
+    raw.impl.combineForms(
+    Forms.raw(forms.run),
+    js.undefined,
+    options.orUndefined
+  ).asInstanceOf[Reducer[S, A]]
+  )
+
+  def combineFormsUnscoped[S, A](
+    forms: Unscoped[S, Forms[S, A]],
+    options: Option[CombineFormsOptions] = None
+  ): Unscoped[S, Reducer[S, A]] = Unscoped[S, Reducer[S, A]] {
+    case Some(lens) => combineForms(forms, lens, options).run
+    case None => combineForms(forms.scopeSelf, options).run
+  }
+
+  def modelReducer[G, S, A](
+    model: StringLens[G, S],
+    initialState: S
+  ): Scoped[G, Reducer[S, A]] = Scoped[G](
     raw.impl.modelReducer(
-      StringLens.run(model),
-      initialState.asInstanceOf[js.Any]
-    ).asInstanceOf[Reducer[S1, A]]
+    StringLens.run(model),
+    initialState.asInstanceOf[js.Any]
+  ).asInstanceOf[Reducer[S, A]]
+  )
 
   // TODO: think of a way to properly type formReducer
 }

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -11,17 +11,27 @@ package object rrf {
 
   type SubmitHandler[S] = js.Function1[S, Unit]
 
+  /**
+   * An opaque type for data used by formReducer.
+   */
+  @js.native
+  trait RRFStateValue extends js.Any
+
+  type RRFState = js.UndefOr[RRFStateValue]
+
+  // TODO: better typing here
+  type Plugin = js.Any
+
   @ScalaJSDefined
-  trait CombineFormsOptions extends js.Object {
+  private trait CombineFormsOptions extends js.Object {
     val key: js.UndefOr[String] = js.undefined
-    // TODO: better typing here
-    val plugins: js.UndefOr[js.Array[_]] = js.undefined
+    val plugins: js.UndefOr[js.Array[Plugin]] = js.undefined
   }
 
-  object CombineFormsOptions {
+  private object CombineFormsOptions {
     def apply(
       key: Option[String] = None,
-      plugins: Option[js.Array[_]] = None
+      plugins: Option[js.Array[Plugin]] = None
     ) = {
       val key0 = key
       val plugins0 = plugins
@@ -33,34 +43,48 @@ package object rrf {
   }
 
   def combineForms[G, S, A](
-    forms: Unscoped[S, Forms[S, A]],
+    forms: Forms[S, A],
     model: StringLens[G, S],
-    options: Option[CombineFormsOptions]
-  ): Scoped[G, Reducer[S, A]] = Scoped[G](
-    raw.impl.combineForms(
-    Forms.raw(forms.scope(model).run),
-    StringLens.run(model),
-    options.orUndefined
-  ).asInstanceOf[Reducer[S, A]]
-  )
+    plugins: List[Plugin] = Nil
+  ): Scoped[G, Reducer[S, A]] = {
+    val Forms.Result(key, formsObject) = Forms.run(forms).scope(model).run
+    val options = CombineFormsOptions(
+      Some(StringLens.run(key)),
+      Some(plugins).filter(_.nonEmpty).map(_.toJSArray)
+    )
+    Scoped[G](
+      raw.impl.combineForms(
+      formsObject,
+      StringLens.run(model),
+      options
+    ).asInstanceOf[Reducer[S, A]]
+    )
+  }
 
-  def combineForms[S, A](
-    forms: Scoped[S, Forms[S, A]],
-    options: Option[CombineFormsOptions] = None
-  ): Scoped[S, Reducer[S, A]] = Scoped[S](
-    raw.impl.combineForms(
-    Forms.raw(forms.run),
-    js.undefined,
-    options.orUndefined
-  ).asInstanceOf[Reducer[S, A]]
-  )
+  def combineForms[G, A](
+    forms: Forms[G, A],
+    plugins: List[Plugin]
+  ): Scoped[G, Reducer[G, A]] =
+    combineForms[G, G, A](
+      forms,
+      StringLens.self,
+      plugins
+    )
+
+  def combineForms[G, A](
+    forms: Forms[G, A]
+  ): Scoped[G, Reducer[G, A]] =
+    combineForms[G, G, A](
+      forms,
+      StringLens.self
+    )
 
   def combineFormsUnscoped[S, A](
-    forms: Unscoped[S, Forms[S, A]],
-    options: Option[CombineFormsOptions] = None
+    forms: Forms[S, A],
+    plugins: List[Plugin] = Nil
   ): Unscoped[S, Reducer[S, A]] = Unscoped[S, Reducer[S, A]] {
-    case Some(lens) => combineForms(forms, lens, options).run
-    case None => combineForms(forms.scopeSelf, options).run
+    case Some(lens) => combineForms(forms, lens, plugins).run
+    case None => combineForms(forms, plugins).run
   }
 
   def modelReducer[G, S, A](
@@ -73,5 +97,19 @@ package object rrf {
   ).asInstanceOf[Reducer[S, A]]
   )
 
-  // TODO: think of a way to properly type formReducer
+  def formReducer[G, S](
+    model: StringLens[G, S],
+    initialState: Option[S] = None,
+    // TODO: expose more options
+    plugins: List[Plugin] = Nil
+  ): Scoped[G, Reducer[RRFState, Any]] = Scoped[G](
+    raw.impl.formReducer(
+    StringLens.run(model),
+    initialState.map(_.asInstanceOf[js.Any]).orUndefined,
+    // TODO: this needs a proper type
+    js.Dynamic.literal(
+      plugins = plugins.toJSArray
+    ).asInstanceOf[js.Object]
+  ).asInstanceOf[Reducer[RRFState, Any]]
+  )
 }

--- a/src/main/scala/util/chainReducers.scala
+++ b/src/main/scala/util/chainReducers.scala
@@ -1,0 +1,53 @@
+package eldis.redux.rrf.util
+
+import eldis.redux.Reducer
+import eldis.redux.rrf.{ Scoped, Unscoped, StringLens }
+
+/**
+ * Custom alternative to `combineReducers`
+ *
+ * Applies provided reducers sequentially.
+ * Assumes that the resulting reducer is a global one.
+ * Assumes that the initial state is present.
+ */
+object chainReducers {
+
+  def apply[G, A](items: Item[G, A]*): Reducer[G, A] =
+    (s: G, a: A) => items.foldLeft(s) {
+      (acc, item) => item.value.run(acc, a)
+    }
+
+  /**
+   * Magnet to support reducers in different forms
+   */
+  case class Item[G, -A](value: Scoped[G, Reducer[G, A]])
+
+  object Item {
+
+    implicit def simpleItem[G, A](v: Scoped[G, Reducer[G, A]]): Item[G, A] = Item(v)
+
+    implicit def unwrappedReducerItem[G, A](r: Reducer[G, A]): Item[G, A] =
+      Item(Scoped[G](r))
+
+    implicit def rootUnscopedReducerItem[G, A](
+      u: Unscoped[G, Reducer[G, A]]
+    ): Item[G, A] =
+      Item(u.scopeSelf)
+
+    implicit def unscopedReducerItem[G, S, A](
+      t: (StringLens[G, S], Unscoped[S, Reducer[S, A]])
+    ): Item[G, A] = {
+      val (lens, u) = t
+      val scopedLocal: Scoped[G, Reducer[S, A]] = u.scope(lens)
+      val scopedGlobal: Scoped[G, Reducer[G, A]] =
+        Scoped[G](reducerOver(lens, scopedLocal.run))
+      Item[G, A](scopedGlobal)
+    }
+
+    private def reducerOver[G, S, A](
+      lens: StringLens[G, S],
+      r: Reducer[S, A]
+    ): Reducer[G, A] =
+      (s: G, a: A) => StringLens.over(lens, s)(r(_, a))
+  }
+}

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -1,0 +1,7 @@
+package eldis.redux.rrf
+
+/**
+ * Various useful functions that don't use RRF API as such,
+ * but are implemented using functionality provided by this package.
+ */
+package object util

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -1,7 +1,20 @@
 package eldis.redux.rrf
 
+import eldis.redux.Reducer
+
 /**
  * Various useful functions that don't use RRF API as such,
  * but are implemented using functionality provided by this package.
  */
-package object util
+package object util {
+  def reducerOver[G, S, A](
+    lens: StringLens[G, S],
+    r: Reducer[S, A]
+  ): Reducer[G, A] =
+    (s: G, a: A) => StringLens.over(lens)(r(_, a))(s)
+
+  def joinReducers[S, A](
+    reducers: List[Reducer[S, A]]
+  ): Reducer[S, A] =
+    (s: S, a: A) => reducers.foldLeft(s)((s, r) => r(s, a))
+}

--- a/src/test/scala/GenLensSpec.scala
+++ b/src/test/scala/GenLensSpec.scala
@@ -17,10 +17,10 @@ class GenLensSpec extends FunSpec with Matchers {
       import f._
 
       val xL = GenLens[Foo](_.x)
-      runSL(xL) shouldBe ".x"
+      runSL(xL) shouldBe "x"
 
       val fooxL = GenLens[Bar](_.foo.x)
-      runSL(fooxL) shouldBe ".foo.x"
+      runSL(fooxL) shouldBe "foo.x"
     }
   }
 }

--- a/src/test/scala/ModelLensSpec.scala
+++ b/src/test/scala/ModelLensSpec.scala
@@ -62,7 +62,7 @@ class ModelLensSpec extends FunSpec with Matchers {
       val f = modelFixture
       import f._
 
-      val out = ModelLens.over((fooLens >>> indexLens >>> barLens), model)(_ + 333)
+      val out = ModelLens.over(fooLens >>> indexLens >>> barLens)(_ + 333)(model)
 
       out.foo(0).bar should equal(111)
       out.foo(1).bar should equal(555)

--- a/src/test/scala/ModelLensSpec.scala
+++ b/src/test/scala/ModelLensSpec.scala
@@ -57,6 +57,20 @@ class ModelLensSpec extends FunSpec with Matchers {
       val barAtIndex = a.bar.asInstanceOf[js.Array[Int]](2)
       assert((baz >>> index)(a) == barAtIndex.asInstanceOf[js.Any])
     }
+
+    it("should properly modify the object (over)") {
+      val f = modelFixture
+      import f._
+
+      val out = ModelLens.over((fooLens >>> indexLens >>> barLens), model)(_ + 333)
+
+      out.foo(0).bar should equal(111)
+      out.foo(1).bar should equal(555)
+      out.foo(2).bar should equal(333)
+
+      // Shouldn't change the source
+      model.foo(1).bar should equal(222)
+    }
   }
 }
 

--- a/src/test/scala/util/chainReducersSpec.scala
+++ b/src/test/scala/util/chainReducersSpec.scala
@@ -1,0 +1,98 @@
+package eldis.redux.rrf.util
+
+import org.scalatest._
+import scala.scalajs.js
+import js.annotation.ScalaJSDefined
+
+import eldis.redux.Reducer
+import eldis.redux.rrf.{ Scoped, Unscoped, StringLens }
+
+class chainReducersSpec extends FunSpec with Matchers {
+
+  def fixture = new Fixture {}
+
+  trait Fixture {
+
+    type State = chainReducersSpec.State
+
+    val baseState = new State {
+      val foo = List()
+      val bar = 0
+    }
+
+    val r1: Reducer[List[Int], Unit] = (s: List[Int], a: Unit) => s :+ 1
+    val r2: Reducer[List[Int], Unit] = (s: List[Int], a: Unit) => s :+ 2
+
+    val sr: Scoped[List[Int], Reducer[List[Int], Unit]] =
+      Scoped[List[Int]]((s: List[Int], a: Unit) => s :+ s.length)
+
+    val urState: Unscoped[State, Reducer[State, Int]] =
+      Unscoped[State, Reducer[State, Int]] {
+        case Some(lens) => fail() // shouldn't scope this!
+        case None => (s: State, a: Int) => new State {
+          val foo = s.foo
+          val bar = a + s.foo.length
+        }
+      }
+
+    val urFoo: Unscoped[List[Int], Reducer[List[Int], Int]] =
+      Unscoped[List[Int], Reducer[List[Int], Int]] {
+        case Some(lens) =>
+          assert(StringLens.run(lens) == "foo")
+          (s: List[Int], a: Int) => s :+ (11 * a)
+        case None => fail() // shouldn't use this directly!
+      }
+  }
+
+  describe("chainReducers") {
+    it("should work for unwrapped reducers") {
+      val f = fixture
+      import f._
+
+      chainReducers()(Nil, ()) should be(Nil)
+      chainReducers(r1)(Nil, ()) should be(List(1))
+      chainReducers(r1, r2)(Nil, ()) should be(List(1, 2))
+      chainReducers(r1, r2, r1)(Nil, ()) should be(List(1, 2, 1))
+    }
+
+    it("should work for scoped reducers") {
+
+      val f = fixture
+      import f._
+
+      chainReducers(sr, sr, sr)(Nil, ()) should be(List(0, 1, 2))
+    }
+
+    it("should work for unscoped reducers") {
+
+      val f = fixture
+      import f._
+
+      val s1 = chainReducers(urState)(baseState, 1)
+      s1.foo should be(List())
+      s1.bar should be(1)
+
+      val s2 = chainReducers(
+        StringLens[State, List[Int]]("foo") -> urFoo
+      )(baseState, 2)
+      s2.foo should be(List(22))
+      s2.bar should be(0)
+
+      val s3 = chainReducers(
+        StringLens[State, List[Int]]("foo") -> urFoo,
+        urState
+      )(baseState, 3)
+      s3.foo should be(List(33))
+      s3.bar should be(4)
+    }
+  }
+}
+
+object chainReducersSpec {
+
+  @ScalaJSDefined
+  trait State extends js.Object {
+    val foo: List[Int]
+    val bar: Int
+  }
+}


### PR DESCRIPTION
## Scope tracking
We generally have to provide full path in global state to create a reducer (to filter rrf events). This PR adds two wrappers:
- `Scoped[G, T]` - wraps an object of `T` that assumes the top-level state is of type `G`
- `Unscoped[S, T]` - produces a `Scoped[G, T]` for any `StringLens[G, S]`

Hopefully, this should allow at least some type safety in `combineForms` and others.

## Lenses cleanup
Add separate types for partial lenses. Recommended lens usage now looks like this:
```scala
// Full lens
GenLens[Foo](_.bar.baz)
// Partial lens
GenLens[Bar](_.baz).partial
```
With this we remove the need for `StringLens` in the most common scenarios.

## chainReducers
A custom alternative to `combineReducers`. Accepts a collection of reducer-like parameters in following shapes:
- `Scoped[G, Reducer[G, A]]`
- `Unscoped[G, Reducer[G, A]]`
- `(StringLens[G, S], Unscoped[S, Reducer[S, A]])`
- `Forms[G, A]`
- `Unscoped[S, Forms[S, A]]`

## Various API tweaks